### PR TITLE
dpca_classification_plot details

### DIFF
--- a/matlab/dpca_classificationPlot.m
+++ b/matlab/dpca_classificationPlot.m
@@ -1,5 +1,76 @@
-function dpca_classificationPlot(accuracy, brier, accuracyShuffle, brierShuffle, decodingClasses)
+function dpca_classificationPlot(accuracy, brier, accuracyShuffle, brierShuffle, decodingClasses, varargin)
+% dpca_classificationPlot(accuracy, brier, accuracyShuffle, brierShuffle, decodingClasses)
+% Plots the output of dpca_classificationAccuracy and dpca_classificationShuffled
+% Only the accuracy input is required, other inputs may be []
+%
+% [...] = dpca_classificationPlot(..., 'PARAM1',val1, 'PARAM2',val2, ...) 
+% specifies optional parameter name/value pairs:
+%
+%  'time'                   - time axis
+%
+%  'timeEvents'             - time-points that should be marked on each subplot
+%
+%  'whichMarg'              - which marginalization each component comes
+%                             from. Is provided as an output of the dpca()
+%                             function.
+%
+%  'marginalizationNames'   - names of each marginalization
+%
+% Note that the calculation of the accuracy in dpca_classificationAccuracy
+% does its own dPCA internally, and it is possible that the order of
+% components obtained therein is different to the order of components
+% obtained externally when you calculated whichMarg. Therefore, it is not
+% guaranteed that whichMarg component numbers will match exactly the
+% component numbers in the plot.
 
+% default input parameters
+options = struct('time',                    [], ...   
+                 'whichMarg',               [], ...
+                 'marginalizationNames',	[],...
+                 'timeEvents',              []);
+
+% read input parameters
+optionNames = fieldnames(options);
+if mod(length(varargin),2) == 1
+	error('Please provide propertyName/propertyValue pairs')
+end
+for pair = reshape(varargin,2,[])    % pair is {propName; propValue}
+	if any(strcmp(pair{1}, optionNames))
+        options.(pair{1}) = pair{2};
+    else
+        error('%s is not a recognized parameter name', pair{1})
+	end
+end
+
+% Get the time-axis values
+if ~isempty(options.time) && length(options.time) >= size(accuracy, 3)
+    acc_time = options.time(1:size(accuracy, 3));
+else
+    acc_time = 1:size(accuracy, 3);
+end
+if ~isempty(accuracyShuffle)
+    if ~isempty(options.time) && length(options.time) >= size(accuracyShuffle, 2)
+        sh_time = options.time(1:size(accuracyShuffle, 2));
+    else
+        sh_time = 1:size(accuracyShuffle, 2);
+    end
+end
+if ~isempty(brier)
+    if ~isempty(options.time) && length(options.time) >= size(brier, 3)
+        br_time = options.time(1:size(brier, 3));
+    else
+        br_time = 1:size(brier, 3);
+    end
+end
+if ~isempty(brierShuffle)
+    if ~isempty(options.time) && length(options.time) >= size(brierShuffle, 2)
+        brsh_time = options.time(1:size(brierShuffle, 2));
+    else
+        brsh_time = 1:size(brierShuffle, 2);
+    end
+end
+
+numClasses = zeros(1, length(decodingClasses));
 for i=1:length(decodingClasses)
     numClasses(i) = length(unique(decodingClasses{i}));
 end
@@ -13,17 +84,29 @@ figure
 for i=setdiff(1:size(accuracy,1), timeComp)
     for j=1:size(accuracy,2)
         subplot(length(rows)-1,3,(rows(i)-1)*3+j)
-        title(['Marginalization #' num2str(i)])
+        if ~isempty(options.marginalizationNames) && ~isempty(options.whichMarg)
+            comp_id = find(options.whichMarg==i, j);
+            title([options.marginalizationNames{i} ' (comp. ' num2str(comp_id(end)) ')'])
+        else
+            title([options.marginalizationNames{i} ' # ' num2str(i)])
+        end
+
         hold on
-        axis([0 size(accuracy,3) 0 1])
+        axis([min(acc_time) max(acc_time) 0 1])
+        
+        if i == max(setdiff(1:size(accuracy,1), timeComp))
+            xlabel('Time (s)')
+        end
+        if j==1
+            ylabel(sprintf('Classification\nAccuracy'))
+        end
         
         if ~isempty(accuracyShuffle)
-            axis([1 size(accuracy,3) 0 1])
+            axis([min(sh_time) max(sh_time) 0 1])
             hold on
             maxSh = max(accuracyShuffle(i,:,:),[],3);
             minSh = min(accuracyShuffle(i,:,:),[],3);
-            time = 1:length(maxSh);
-            h = patch([time fliplr(time)], [maxSh fliplr(minSh)], 'b');
+            h = patch([sh_time fliplr(sh_time)], [maxSh fliplr(minSh)], 'b');
             set(h, 'FaceAlpha', 0.5)
             set(h, 'EdgeColor', 'none')
         end
@@ -31,8 +114,7 @@ for i=setdiff(1:size(accuracy,1), timeComp)
         if ~isempty(brierShuffle)
             maxSh = max(brierShuffle(i,:,:),[],3);
             minSh = min(brierShuffle(i,:,:),[],3);
-            time = 1:length(maxSh);
-            h = patch([time fliplr(time)], [maxSh fliplr(minSh)], 'r');
+            h = patch([brsh_time fliplr(brsh_time)], [maxSh fliplr(minSh)], 'r');
             set(h, 'FaceAlpha', 0.5)
             set(h, 'EdgeColor', 'none')
         end
@@ -41,12 +123,14 @@ for i=setdiff(1:size(accuracy,1), timeComp)
             plot(xlim, 1/numClasses(i)*[1 1], 'k')
         end
         
-        if ~isempty(accuracy)
-            plot(squeeze(accuracy(i,j,:)))
-        end
+        plot(acc_time, squeeze(accuracy(i,j,:)), 'b')  % Plot this after above to make sure it is drawn on top
         
         if ~isempty(brier)
-            plot(squeeze(brier(i,j,:)), 'r')
+            plot(br_time, squeeze(brier(i,j,:)), 'r')
+        end
+        
+        if ~isempty(options.timeEvents)
+            plot([options.timeEvents', options.timeEvents'], [0 1], 'Color', [0.6 0.6 0.6])
         end
     end
 end

--- a/matlab/dpca_plot.m
+++ b/matlab/dpca_plot.m
@@ -101,10 +101,13 @@ if ~isempty(options.whichMarg) && ...
     subplots = [];
     for i=1:length(margRowSeq)
         if ~isempty(options.componentsSignif) && margRowSeq(i) ~= options.timeMarginalization
-            % selecting only significant components
+            % prefer significant components
             minL = min(length(options.whichMarg), size(options.componentsSignif,1));
             moreComponents = find(options.whichMarg(1:minL) == margRowSeq(i) & ...
                 sum(options.componentsSignif(1:minL,:), 2)'~=0, 3);
+            if length(moreComponents) < 3
+                moreComponents = [moreComponents setdiff(find(options.whichMarg == margRowSeq(i), 3), moreComponents)];
+            end
         else
             moreComponents = find(options.whichMarg == margRowSeq(i), 3);
         end

--- a/matlab/dpca_plot.m
+++ b/matlab/dpca_plot.m
@@ -43,6 +43,10 @@ function dpca_plot(Xfull, W, V, plotFunction, varargin)
 %  'X_extra'                - data array used for plotting that can be larger
 %                             (i.e. have more conditions) than the one used
 %                             for dpca computations
+%  'showNonsignificantComponents'
+%                           - display non-signficant components when there
+%                             are fewer significant components than
+%                             subplots
 
 % default input parameters
 options = struct('time',           [], ...   
@@ -56,7 +60,8 @@ options = struct('time',           [], ...
                  'marginalizationColours', [], ...
                  'explainedVar',   [], ...
                  'numCompToShow',  15, ...
-                 'X_extra',        []);
+                 'X_extra',        [], ...
+                 'showNonsignificantComponents', false);
 
 % read input parameters
 optionNames = fieldnames(options);
@@ -101,11 +106,12 @@ if ~isempty(options.whichMarg) && ...
     subplots = [];
     for i=1:length(margRowSeq)
         if ~isempty(options.componentsSignif) && margRowSeq(i) ~= options.timeMarginalization
-            % prefer significant components
+            % selecting only significant components
             minL = min(length(options.whichMarg), size(options.componentsSignif,1));
             moreComponents = find(options.whichMarg(1:minL) == margRowSeq(i) & ...
                 sum(options.componentsSignif(1:minL,:), 2)'~=0, 3);
-            if length(moreComponents) < 3
+            if options.showNonsignificantComponents && (length(moreComponents) < 3)
+                % Optionally add non-significant components to fill subplots
                 moreComponents = [moreComponents setdiff(find(options.whichMarg == margRowSeq(i), 3), moreComponents)];
             end
         else


### PR DESCRIPTION
Adds some details to the classification accuracy plot.

Also another commit that fills out the dpca_plot with non-significant components if there aren't enough significant components to fill the plot. This one is pretty subjective: I prefer useless information over asymmetric white space.

Let me know if having empty subplot spaces is preferred but the classification accuracy plot enhancements are still desired then I will modify this PR.