### PR TITLE
Update setuptools `requires` keyword to `install_requires`

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -34,5 +34,5 @@ setup(name=NAME,
       license=LICENSE,
       packages=['dPCA'],
       package_data={},
-      install_requires=['sklearn', 'numexpr', 'numba']
+      install_requires=['numpy', 'scipy', 'sklearn', 'numexpr', 'numba']
       )

--- a/python/setup.py
+++ b/python/setup.py
@@ -34,5 +34,5 @@ setup(name=NAME,
       license=LICENSE,
       packages=['dPCA'],
       package_data={},
-      requires=['sklearn', 'numexpr', 'numba']
+      install_requires=['sklearn', 'numexpr', 'numba']
       )


### PR DESCRIPTION
When I `pip install dpca` on Python 3.8, it does not install the dependencies (`numexpr`, etc.), because the `requires` keyword has been deprecated and updated to `install_requires`: https://setuptools.pypa.io/en/latest/references/keywords.html

This PR fixes this and also adds `numpy` and `scipy` to the `install_requires` list.