### PR TITLE
Rename sklearn to scikit-learn in `requirements.txt`

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,5 +1,5 @@
 numpy
 scipy
 numexpr
-sklearn
+scikit-learn
 numba


### PR DESCRIPTION
as recommended by https://pypi.org/project/sklearn/