### PR TITLE
Add pyproject.toml and update dependencies

### DIFF
--- a/python/dPCA/dPCA.py
+++ b/python/dPCA/dPCA.py
@@ -97,11 +97,12 @@ class dPCA(BaseEstimator):
             self.labels = labels
         elif isinstance(labels,int):
             alphabet = 'abcdefghijklmnopqrstuvwxyz'
-            labels = alphabet[:labels]
+            self.labels = alphabet[:labels]
         else:
             raise TypeError('Wrong type for labels. Please either set labels to the number of variables or provide the axis labels as a single string of characters (like "ts" for time and stimulus)')
 
         self._join = join
+        self.join = join
         self.regularizer = 0 if regularizer == None else regularizer
         self.opt_regularizer_flag = regularizer == 'auto'
         self.n_components = n_components
@@ -651,7 +652,7 @@ class dPCA(BaseEstimator):
         protected = self._check_protected(trialX,protect)
 
         # reorder matrix to protect certain axis (for speedup)
-        if ~protected:
+        if not(protected):
             # turn crossval_protect into index listX
             axes = [self.labels.index(ax) + 2 for ax in protect]
 
@@ -680,7 +681,7 @@ class dPCA(BaseEstimator):
         trainX = (X*(N_samples/(N_samples-1))[(np.s_[:],)*n_unprotect + (None,)*n_protect] - blindX/(N_samples-1)[(np.s_[:],)*n_unprotect + (None,)*n_protect])
 
         # inverse rolled axis in blindX
-        if ~protected:
+        if not(protected):
             blindX = self._roll_back(blindX[...,None],axes,invert=True)[...,0]
             trainX = self._roll_back(trainX[...,None],axes,invert=True)[...,0]
 
@@ -710,7 +711,7 @@ class dPCA(BaseEstimator):
         protected = self._check_protected(trialX,protect)
 
         # reorder matrix to protect certain axis (for speedup)
-        if ~protected:
+        if not(protected):
             # turn crossval_protect into index list
             axes = [self.labels.index(ax) + 2 for ax in protect]
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,0 +1,31 @@
+[build-system]
+requires = ["setuptools>=64", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "dPCA"
+version = "1.0.5"
+description = "Implements Demixed Principal Components Analysis"
+readme = "README.rst"
+license = {text = "MIT"}
+authors = [
+    {name = "Machens Lab", email = "wieland.brendel@uni-tuebingen.de"}
+]
+maintainers = [
+    {name = "Wieland Brendel", email = "wieland.brendel@uni-tuebingen.de"}
+]
+requires-python = ">=3.7"
+dependencies = [
+    "numpy",
+    "scipy",
+    "scikit-learn",
+    "numexpr",
+    "numba"
+]
+
+[project.urls]
+Homepage = "https://github.com/machenslab/dPCA/"
+Download = "https://github.com/machenslab/dPCA/"
+
+[tool.setuptools.packages.find]
+include = ["dPCA*"]

--- a/python/setup.py
+++ b/python/setup.py
@@ -34,5 +34,5 @@ setup(name=NAME,
       license=LICENSE,
       packages=['dPCA'],
       package_data={},
-      install_requires=['numpy', 'scipy', 'sklearn', 'numexpr', 'numba']
+      install_requires=['numpy', 'scipy', 'scikit-learn', 'numexpr', 'numba']
       )


### PR DESCRIPTION
**Add pyproject.toml and update dependencies**

These changes serve to make initial install of dPCA easier and update several deprecations.

## Changes
* Add `pyproject.toml` to enable modern PEP 517 build system
* Update `setup.py` to use `scikit-learn` instead of deprecated `sklearn` package name
* Fix deprecated `__invert__` usage on bools in `dPCA.py` (lines 654, 683, 713) - replace with `not` operator to avoid errors in Python 3.16+
* Add `join` attribute to store `_join` value for HTML repr compatibility (line 104 in `dPCA.py`)

## Motivation
Fixes the legacy editable install deprecation warning when running:
`pip install -e .`

```
DEPRECATION: Legacy editable install of dPCA==1.0.5 from file:///... (setup.py develop) is deprecated. 
pip 25.3 will enforce this behaviour change.
```

This modernizes the package build configuration to comply with current Python packaging standards and ensures compatibility with pip 25.3+.

Additionally addresses Python 3.16 compatibility by removing deprecated `__invert__` calls on boolean values, which will throw errors in future Python versions.

The `join` attribute addition enables proper HTML object representation without breaking the existing `_join` internal implementation.

## Testing
* Verified `pip install -e .` installs without warnings
* Confirmed package imports and basic functionality work correctly
* Tested HTML repr generation with new `join` attribute
* Verified logical negation changes produce correct behavior

---

This version provides clear documentation of all the changes while explaining the technical reasoning behind each modification.